### PR TITLE
Add building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ You can join our discord server: https://discord.gg/Ct2vzGK
   - Get the satellites name
   - Cut off bad start and end
 
+# Building from source
+First install `maven`.
+```
+git clone https://github.com/ZbychuButItWasTaken/NOAA_HIRS_Decoder.git
+cd NOAA_HIRS_Decoder
+mvn compile
+mvn package
+```
+
 # TODO
  - GUI
  - ~~Cloud top height approximation~~ Isn't possible because of the degraded performance of HIRS instrument


### PR DESCRIPTION
I experimented with maven and added build instructions to README. I was able to build successfully with those steps, producing the files `NOAA_HIRS_Decoder-1.0.2.jar` `NOAA_HIRS_Decoder-1.0.2-jar-with-dependencies.jar` `NOAA_HIRS_Decoder.exe`. Would you like to check the steps and see if they are what you want?